### PR TITLE
⚡ Bolt: Optimize virtualized list scrolling performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,5 @@
 ## 2024-05-18 - Prevent VariableSizeList Unnecessary Re-renders
 **Learning:** Using an inline object for `itemData` prop in `react-window`'s `VariableSizeList` breaks `React.memo` for the list items (e.g. `SearchResultItem`), causing them to re-render on every list update, scroll, or state change, regardless of whether their props have actually changed.
-**Action:** Always wrap `itemData` and its dependencies (like functions e.g. `gotoArticle`) using `useMemo` and `useCallback` when using `react-window` to ensure that item components are not unnecessarily re-rendered.
+**Action:** Always wrap `itemData` and its dependencies (like functions e.g. `gotoArticle`) using `useMemo` and `useCallback` when using `react-window` to ensure that item components are not unnecessarily re-rendered.## 2026-04-05 - Virtualized List Style Reference Thrashing
+**Learning:** Virtualized list components (like `react-window` or custom implementations like `FixedSizeList`) pass a new `style` object reference to child items on every scroll event, defeating `React.memo` shallow comparison and causing unnecessary deep re-renders.
+**Action:** Always wrap virtualized item components in `React.memo` and provide a custom `arePropsEqual` comparator that deep-compares the keys and values of the `style` prop while shallow-comparing everything else.

--- a/src/components/Widgets/Table.js
+++ b/src/components/Widgets/Table.js
@@ -10,7 +10,7 @@ import { useTranslations } from "@util/translations";
 import { useDeviceType } from "@util/styles";
 import { importData, exportData } from "@util/importExport";
 import Row from "./Table/Row";
-import Item from "./Table/Item";
+import Item, { arePropsEqual } from "./Table/Item";
 import Navigator from "./Table/Navigator";
 import { useSearch } from "@components/Search";
 import { registerToolbar, useToolbar } from "@components/Toolbar";
@@ -805,7 +805,7 @@ const TableListRow = React.memo(({ index, style, data }) => {
             />
         </>
     );
-});
+}, arePropsEqual);
 
 TableListRow.displayName = "TableListRow";
 
@@ -838,6 +838,6 @@ const TableGridCell = React.memo(({ columnIndex, rowIndex, style, data }) => {
         selected={selected}
         renderColumn={renderColumn}
     />;
-});
+}, arePropsEqual);
 
 TableGridCell.displayName = "TableGridCell";

--- a/src/components/Widgets/Table/Item.js
+++ b/src/components/Widgets/Table/Item.js
@@ -7,7 +7,7 @@ import { useStyles } from "@util/styles";
 // Performance optimization: Custom comparator to handle 'style' prop stability.
 // The 'style' prop from react-window often changes reference but contains the same values.
 // This prevents unnecessary re-renders of table cells when selection changes or during non-layout updates.
-function arePropsEqual(prev, next) {
+export function arePropsEqual(prev, next) {
     if (prev === next) return true;
     const keysA = Object.keys(prev);
     const keysB = Object.keys(next);

--- a/src/views/Research/SearchResultItem.js
+++ b/src/views/Research/SearchResultItem.js
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useMemo } from "react";
 import styles from "./SearchResultItem.module.css";
 import Article from "@views/Library/Article";
 import { normalizeContent, preprocessMarkdown } from "@util/string";
+import { arePropsEqual } from "@components/Widgets/Table/Item";
 
 const SearchResultItem = ({ index, style, data }) => {
     const { results, gotoArticle, setRowHeight, highlight } = data || {};
@@ -77,4 +78,4 @@ const SearchResultItem = ({ index, style, data }) => {
     );
 };
 
-export default React.memo(SearchResultItem);
+export default React.memo(SearchResultItem, arePropsEqual);

--- a/src/views/Schedule/TracksView.js
+++ b/src/views/Schedule/TracksView.js
@@ -9,6 +9,8 @@ import { ContentSize } from "@components/Page/Content";
 import Input from "@components/Widgets/Input";
 import { useDateFormatter } from "@util/locale";
 import TodayIcon from '@mui/icons-material/Today';
+import { arePropsEqual } from "@components/Widgets/Table/Item";
+import React from "react";
 
 registerToolbar("TracksView");
 
@@ -359,7 +361,7 @@ export default function TracksView({ sessions = [], store, translations, playing
     );
 }
 
-const Row = ({ index, style, data }) => {
+const Row = React.memo(({ index, style, data }) => {
     const { groupedSessions, focusedSessionId, handleSessionClick, width, itemSize, store, translations, playingSession } = data;
     const group = groupedSessions[index];
 
@@ -379,4 +381,4 @@ const Row = ({ index, style, data }) => {
             />
         </div>
     );
-};
+}, arePropsEqual);


### PR DESCRIPTION
💡 What: Exported an existing `arePropsEqual` comparator from `Table/Item.js` and applied it to multiple virtualized list row components (`TableListRow`, `TableGridCell`, `TracksView Row`, `SearchResultItem`) via `React.memo`.

🎯 Why: Virtualization components (like `react-window` or `FixedSizeList`) pass a new `style` object reference down to row items during every scroll update. Without a custom comparator, standard `React.memo` (or no memoization at all) fails the shallow equality check, causing deep re-renders of list items even when their content hasn't changed.

📊 Impact: Significantly reduces React component re-renders during scrolling in the Schedule tracks, Research search results, and Table view layouts. This leads to smoother scrolling and lower CPU usage.

🔬 Measurement: Profile the application during scrolling in the Research view or Schedule tracks. You should see fewer deep re-render updates inside the virtual list item components.

---
*PR created automatically by Jules for task [13455010277998738901](https://jules.google.com/task/13455010277998738901) started by @zakaihamilton*