### PR TITLE
🎨 Palette: Add ARIA labels to Transcript search IconButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-08 - Accessible IconButton Labels in Transcript Search
+**Learning:** Icon-only buttons used for sub-components (like Transcript search pagination) without explicit `aria-label`s are a common accessibility gap, even if they're wrapped in Tooltips. Next.js/Material UI don't derive accessible names from Tooltips for screen readers natively on the button.
+**Action:** Always map the name/tooltip title or explicit translations directly to the `aria-label` attribute on the `IconButton` itself when no visible text is present.

--- a/src/views/Player/Transcript.js
+++ b/src/views/Player/Transcript.js
@@ -293,12 +293,12 @@ export default function Transcript({ show }) {
         {!!searchTerm && matches.length > 0 && showHeader && createPortal(<div className={styles.searchStatus}>
             <div className={styles.searchActions}>
                 <Tooltip title={prevName} arrow>
-                    <IconButton onClick={prevMatch} size="small">
+                    <IconButton onClick={prevMatch} size="small" aria-label={prevName}>
                         <ArrowUpwardIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>
                 <Tooltip title={nextName} arrow>
-                    <IconButton onClick={nextMatch} size="small">
+                    <IconButton onClick={nextMatch} size="small" aria-label={nextName}>
                         <ArrowDownwardIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>
@@ -309,7 +309,7 @@ export default function Transcript({ show }) {
                     .replace("{total}", matches.length)}
             </div>
             <Tooltip title={translations.CLOSE} arrow>
-                <IconButton onClick={clearSearch} size="small">
+                <IconButton onClick={clearSearch} size="small" aria-label={translations.CLOSE}>
                     <CloseIcon fontSize="small" />
                 </IconButton>
             </Tooltip>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "Previous Match", "Next Match", and "Clear Search" icon buttons within the Transcript search UI (`src/views/Player/Transcript.js`).
🎯 Why: Icon-only buttons without accessible labels cannot be interpreted by screen readers, even if they are wrapped in tooltips. Explicit `aria-label`s provide clear context for visually impaired users.
♿ Accessibility: Improves keyboard and screen reader navigation within the transcript search panel.

---
*PR created automatically by Jules for task [15896754245976849648](https://jules.google.com/task/15896754245976849648) started by @zakaihamilton*