### PR TITLE
🎨 Palette: Add missing aria-label to icon buttons wrapped in Tooltips

### DIFF
--- a/src/views/Library/Article/ArticleTermsDialog.js
+++ b/src/views/Library/Article/ArticleTermsDialog.js
@@ -112,7 +112,7 @@ export default function ArticleTermsDialog({ open, onClose, terms, onJump }) {
                     />
                     <div className={`${styles.clearButton} ${!search ? styles.hidden : ''}`}>
                         <Tooltip title={translations.CLEAR}>
-                            <IconButton size="small" onClick={() => setSearch("")}>
+                            <IconButton size="small" onClick={() => setSearch("")} aria-label={translations.CLEAR}>
                                 <CloseIcon fontSize="small" />
                             </IconButton>
                         </Tooltip>

--- a/src/views/Library/Article/Zoom.js
+++ b/src/views/Library/Article/Zoom.js
@@ -74,7 +74,7 @@ export default function Zoom({ open, onClose, content, number, badgeClass, Rende
         >
             <DialogContent className={styles.root} {...swipeHandlers}>
                 <Tooltip title={translations.COPY} arrow>
-                    <IconButton className={styles.copyButton} onClick={handleCopy} size="small">
+                    <IconButton className={styles.copyButton} onClick={handleCopy} size="small" aria-label={translations.COPY}>
                         <ContentCopyIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>

--- a/src/views/Player/Transcript.js
+++ b/src/views/Player/Transcript.js
@@ -293,12 +293,12 @@ export default function Transcript({ show }) {
         {!!searchTerm && matches.length > 0 && showHeader && createPortal(<div className={styles.searchStatus}>
             <div className={styles.searchActions}>
                 <Tooltip title={prevName} arrow>
-                    <IconButton onClick={prevMatch} size="small">
+                    <IconButton onClick={prevMatch} size="small" aria-label={prevName}>
                         <ArrowUpwardIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>
                 <Tooltip title={nextName} arrow>
-                    <IconButton onClick={nextMatch} size="small">
+                    <IconButton onClick={nextMatch} size="small" aria-label={nextName}>
                         <ArrowDownwardIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>
@@ -309,7 +309,7 @@ export default function Transcript({ show }) {
                     .replace("{total}", matches.length)}
             </div>
             <Tooltip title={translations.CLOSE} arrow>
-                <IconButton onClick={clearSearch} size="small">
+                <IconButton onClick={clearSearch} size="small" aria-label={translations.CLOSE}>
                     <CloseIcon fontSize="small" />
                 </IconButton>
             </Tooltip>


### PR DESCRIPTION
🎨 Palette: Add missing aria-label to icon buttons wrapped in Tooltips

💡 What: Added missing `aria-label` attributes to `<IconButton>` components located in `src/views/Library/Article/Zoom.js`, `src/views/Library/Article/ArticleTermsDialog.js`, and `src/views/Player/Transcript.js`.

🎯 Why: Ensures that screen reader users can understand the purpose of icon-only buttons, even when they are wrapped in visual `<Tooltip>` components.

♿ Accessibility: Explicit `aria-label` tags were provided using existing localized translation strings or contextually relevant local variables.

---
*PR created automatically by Jules for task [7400098164656666121](https://jules.google.com/task/7400098164656666121) started by @zakaihamilton*