### PR TITLE
⚡ Bolt: fix unnecessary TrackRow React.memo re-renders

### DIFF
--- a/src/views/Schedule/TracksView.js
+++ b/src/views/Schedule/TracksView.js
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef, useContext } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef, useContext, memo } from "react";
 import styles from "./TracksView.module.css";
 import TrackRow from "./TracksView/Row";
 import { useToolbar, registerToolbar } from "@components/Toolbar";
@@ -359,7 +359,32 @@ export default function TracksView({ sessions = [], store, translations, playing
     );
 }
 
-const Row = ({ index, style, data }) => {
+
+function arePropsEqual(prev, next) {
+    if (prev === next) return true;
+    const keysA = Object.keys(prev);
+    const keysB = Object.keys(next);
+    if (keysA.length !== keysB.length) return false;
+
+    for (const key of keysA) {
+        if (key === "style") {
+            const styleA = prev.style || {};
+            const styleB = next.style || {};
+            if (styleA === styleB) continue;
+            const sKeysA = Object.keys(styleA);
+            const sKeysB = Object.keys(styleB);
+            if (sKeysA.length !== sKeysB.length) return false;
+            for (const sKey of sKeysA) {
+                if (styleA[sKey] !== styleB[sKey]) return false;
+            }
+        } else {
+            if (prev[key] !== next[key]) return false;
+        }
+    }
+    return true;
+}
+
+const Row = memo(({ index, style, data }) => {
     const { groupedSessions, focusedSessionId, handleSessionClick, width, itemSize, store, translations, playingSession } = data;
     const group = groupedSessions[index];
 
@@ -379,4 +404,4 @@ const Row = ({ index, style, data }) => {
             />
         </div>
     );
-};
+}, arePropsEqual);

--- a/src/views/Schedule/TracksView/Row.js
+++ b/src/views/Schedule/TracksView/Row.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, useCallback, forwardRef } from 'react';
+import { useRef, useEffect, useMemo, forwardRef, memo } from 'react';
 import styles from './Row.module.css';
 import TrackCard from './Card';
 import Typography from '@mui/material/Typography';
@@ -100,26 +100,6 @@ export default function TrackRow({ date, sessions, focusedSessionId, onSessionCl
         playingSession
     }), [sessions, focusedSessionId, onSessionClick, playingSession]);
 
-    // Memoize RowItem component
-    const RowItem = useCallback(({ index, style, data }) => {
-        const { sessions, focusedSessionId, onSessionClick, playingSession } = data;
-        const session = sessions[index];
-        const newStyle = {
-            ...style,
-            left: (parseFloat(style.left) || 0) + 24
-        };
-        const isPlaying = playingSession && playingSession.name === session.name && playingSession.group === session.group && playingSession.date === session.date;
-        return (
-            <div style={newStyle} className={styles.cardContainer}>
-                <TrackCard
-                    session={session}
-                    isActive={session.id === focusedSessionId}
-                    onSessionClick={onSessionClick}
-                    isPlaying={isPlaying}
-                />
-            </div>
-        );
-    }, []);
 
     // Check for overflow to conditionally show indicator
     const hasOverflow = (sessions.length * itemSize + 24) > safeWidth;
@@ -174,3 +154,49 @@ export default function TrackRow({ date, sessions, focusedSessionId, onSessionCl
         </div>
     );
 }
+
+
+function arePropsEqual(prev, next) {
+    if (prev === next) return true;
+    const keysA = Object.keys(prev);
+    const keysB = Object.keys(next);
+    if (keysA.length !== keysB.length) return false;
+
+    for (const key of keysA) {
+        if (key === "style") {
+            const styleA = prev.style || {};
+            const styleB = next.style || {};
+            if (styleA === styleB) continue;
+            const sKeysA = Object.keys(styleA);
+            const sKeysB = Object.keys(styleB);
+            if (sKeysA.length !== sKeysB.length) return false;
+            for (const sKey of sKeysA) {
+                if (styleA[sKey] !== styleB[sKey]) return false;
+            }
+        } else {
+            if (prev[key] !== next[key]) return false;
+        }
+    }
+    return true;
+}
+
+
+const RowItem = memo(({ index, style, data }) => {
+    const { sessions, focusedSessionId, onSessionClick, playingSession } = data;
+    const session = sessions[index];
+    const newStyle = {
+        ...style,
+        left: (parseFloat(style.left) || 0) + 24
+    };
+    const isPlaying = playingSession && playingSession.name === session.name && playingSession.group === session.group && playingSession.date === session.date;
+    return (
+        <div style={newStyle} className={styles.cardContainer}>
+            <TrackCard
+                session={session}
+                isActive={session.id === focusedSessionId}
+                onSessionClick={onSessionClick}
+                isPlaying={isPlaying}
+            />
+        </div>
+    );
+}, arePropsEqual);


### PR DESCRIPTION
⚡ Bolt: Prevent Unnecessary List Item Re-renders in TracksView

💡 **What:** Added `React.memo` with a custom `arePropsEqual` deep-equality comparator to the `Row` and `RowItem` components inside `src/views/Schedule/TracksView.js` and `Row.js`. Extracted `RowItem` out of the parent render body to prevent constant component unmounting.
🎯 **Why:** `react-window` constantly reconstructs inline style objects, destroying shallow prop comparisons on lists/tables when scrolled or resized. 
📊 **Impact:** Reduces deep component tree re-renders and unmounts/remounts by preventing React from re-rendering list items unless their actual style values or data changes.
🔬 **Measurement:** Use React Developer Tools Profiler and scroll the TracksView page; observe that individual rows no longer flash as re-rendered during scroll.

---
*PR created automatically by Jules for task [4181012592722529238](https://jules.google.com/task/4181012592722529238) started by @zakaihamilton*