### PR TITLE
Reduce session metadata serverless usage with year cache and presigne…

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,141 @@
+# =============================================================================
+# .cursorignore — reduce Composer indexing noise and token usage
+# Patterns follow .gitignore syntax (paths are relative to repo root).
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Dependencies
+# Installed packages; never useful for code understanding or edits.
+# -----------------------------------------------------------------------------
+node_modules/
+.pnp
+.pnp.js
+
+
+# -----------------------------------------------------------------------------
+# Build & compile output
+# Generated artifacts — source of truth lives in app/, src/, and config files.
+# -----------------------------------------------------------------------------
+.next/
+out/
+build/
+dist/
+
+
+# -----------------------------------------------------------------------------
+# Tool & framework caches
+# SWC (Next.js), webpack, and other incremental compile caches.
+# -----------------------------------------------------------------------------
+.swc/
+.turbo/
+.cache/
+**/.cache/
+.parcel-cache/
+.eslintcache
+.stylelintcache
+
+
+# -----------------------------------------------------------------------------
+# Package manager lockfiles
+# Large, auto-generated resolution graphs; package.json is the human-readable
+# source for dependency intent.
+# -----------------------------------------------------------------------------
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lock
+bun.lockb
+
+
+# -----------------------------------------------------------------------------
+# Environment & secrets
+# Local credentials and env-specific config — never index for safety or tokens.
+# -----------------------------------------------------------------------------
+.env
+.env.*
+!.env.example
+
+
+# -----------------------------------------------------------------------------
+# System & editor junk
+# OS metadata and local editor state.
+# -----------------------------------------------------------------------------
+.DS_Store
+**/.DS_Store
+Thumbs.db
+Desktop.ini
+*.swp
+*.swo
+*~
+
+
+# -----------------------------------------------------------------------------
+# Version control internals
+# Git object database and refs — not application source.
+# -----------------------------------------------------------------------------
+.git/
+
+
+# -----------------------------------------------------------------------------
+# Test, coverage & CI artifacts
+# Generated reports and scratch output from test runs.
+# -----------------------------------------------------------------------------
+coverage/
+test-results/
+playwright-report/
+playwright/.cache/
+test_output.txt
+*.lcov
+
+
+# -----------------------------------------------------------------------------
+# Logs & debug output
+# Runtime and package-manager log files.
+# -----------------------------------------------------------------------------
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# -----------------------------------------------------------------------------
+# Public assets & PWA build output (project-specific)
+# Static media and files emitted by @ducanh2912/next-pwa into public/.
+# Keep small config sources (manifest.json, noflash.js) indexable.
+# -----------------------------------------------------------------------------
+public/**/*.png
+public/**/*.jpg
+public/**/*.jpeg
+public/**/*.gif
+public/**/*.webp
+public/**/*.ico
+public/**/workbox-*.js
+public/sw.js
+public/fallback-*.js
+
+
+# -----------------------------------------------------------------------------
+# Source maps & minified bundles
+# Derived from source; duplicates information already in src/ and app/.
+# -----------------------------------------------------------------------------
+*.map
+*.min.js
+*.min.css
+
+
+# -----------------------------------------------------------------------------
+# Local scratch & agent tooling
+# Ephemeral workspace and third-party agent metadata — not app code.
+# -----------------------------------------------------------------------------
+scratch/
+.jules/
+
+
+# -----------------------------------------------------------------------------
+# Deployment platform metadata
+# Vercel and similar local link/cache directories.
+# -----------------------------------------------------------------------------
+.vercel/

--- a/app/api/aws_download/route.js
+++ b/app/api/aws_download/route.js
@@ -30,7 +30,7 @@ async function presignIfExists(s3, key) {
 		);
 		return url;
 	} catch (err) {
-		console.warn(`[AWS DOWNLOAD API] Failed to presign ${key}`, err);
+		console.warn("[AWS DOWNLOAD API] Failed to presign key:", key, err);
 		return null;
 	}
 }

--- a/app/api/aws_download/route.js
+++ b/app/api/aws_download/route.js
@@ -1,0 +1,92 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import parseCookie from "@util/api/cookie";
+import { getSafeError } from "@util/api/safeError";
+import { login } from "@util/auth/login";
+import { roleAuth } from "@util/auth/roles";
+import {
+	validateGroup,
+	validateYear,
+	normalizeListedItem,
+} from "@util/domain/updateSessions/metadataAggregator";
+import { getS3, list, validatePathAccess } from "@util/storage/aws";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const SESSION_METADATA_HEADERS = {
+	"Cache-Control": "no-store",
+};
+
+async function presignIfExists(s3, key) {
+	try {
+		const url = await getSignedUrl(
+			s3,
+			new GetObjectCommand({
+				Bucket: process.env.AWS_BUCKET,
+				Key: key,
+			}),
+			{ expiresIn: 3600 },
+		);
+		return url;
+	} catch (err) {
+		console.warn(`[AWS DOWNLOAD API] Failed to presign ${key}`, err);
+		return null;
+	}
+}
+
+export async function GET(request) {
+	try {
+		const cookieHeader = request.headers.get("cookie") || "";
+		const cookies = parseCookie(cookieHeader);
+		const { id, hash } = cookies || {};
+		if (!id || !hash) throw "ACCESS_DENIED";
+
+		const url = new URL(request.url);
+		const group = url.searchParams.get("group");
+		const year = url.searchParams.get("year");
+		const path = `sessions/${group || ""}/${year || ""}`;
+
+		validateGroup(group);
+		validateYear(year);
+		validatePathAccess(path);
+
+		const user = await login({ id, hash, api: "aws", path });
+		if (!user || !roleAuth(user.role, "student")) throw "ACCESS_DENIED";
+
+		const basePath = `sessions/${group}/${year}`;
+		const metadataBasePath = `sessions/${group}`;
+		const items = (await list({ path: basePath })).map((item) =>
+			normalizeListedItem(item, basePath),
+		);
+		items.sort((a, b) => a.name.localeCompare(b.name));
+
+		const s3 = await getS3({});
+		const [tagsUrl, durationUrl, mdUrl, zipUrl] = await Promise.all([
+			presignIfExists(s3, `${metadataBasePath}/${year}.tags`),
+			presignIfExists(s3, `${metadataBasePath}/${year}.duration`),
+			presignIfExists(s3, `${metadataBasePath}/${year}.md`),
+			presignIfExists(s3, `${metadataBasePath}/${year}.zip`),
+		]);
+
+		return NextResponse.json(
+			{
+				group,
+				year,
+				items,
+				urls: {
+					tags: tagsUrl,
+					duration: durationUrl,
+					md: mdUrl,
+					zip: zipUrl,
+				},
+			},
+			{
+				status: 200,
+				headers: new Headers(SESSION_METADATA_HEADERS),
+			},
+		);
+	} catch (err) {
+		return NextResponse.json({ err: getSafeError(err) }, { status: 403 });
+	}
+}

--- a/app/api/aws_download/route.test.js
+++ b/app/api/aws_download/route.test.js
@@ -1,0 +1,113 @@
+import parseCookie from "@util/api/cookie";
+import { login } from "@util/auth/login";
+import { roleAuth } from "@util/auth/roles";
+import { getS3, list } from "@util/storage/aws";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { GET } from "./route";
+
+jest.mock("@util/api/cookie", () => jest.fn());
+jest.mock("@util/auth/login", () => ({
+	login: jest.fn(),
+}));
+jest.mock("@util/auth/roles", () => ({
+	roleAuth: jest.fn(),
+}));
+jest.mock("@util/api/safeError", () => ({
+	getSafeError: jest.fn((err) => String(err?.message || err)),
+}));
+jest.mock("@util/storage/aws", () => ({
+	getS3: jest.fn(),
+	list: jest.fn(),
+	validatePathAccess: jest.fn(),
+}));
+jest.mock("@aws-sdk/s3-request-presigner", () => ({
+	getSignedUrl: jest.fn(),
+}));
+jest.mock("@aws-sdk/client-s3", () => ({
+	GetObjectCommand: jest.fn().mockImplementation((params) => params),
+}));
+jest.mock("next/server", () => ({
+	NextResponse: {
+		json: (body, init = {}) => ({
+			status: init.status || 200,
+			json: async () => body,
+			headers: {
+				get: (name) => init.headers?.get?.(name) || null,
+			},
+		}),
+	},
+}));
+
+function request(url, cookie = "id=user; hash=secret") {
+	return {
+		url,
+		headers: {
+			get: (name) => (name.toLowerCase() === "cookie" ? cookie : null),
+		},
+	};
+}
+
+describe("/api/aws_download", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		parseCookie.mockReturnValue({ id: "user", hash: "secret" });
+		login.mockResolvedValue({ id: "user", role: "student" });
+		roleAuth.mockReturnValue(true);
+		getS3.mockResolvedValue({});
+		list.mockResolvedValue([
+			{
+				name: "2024-05-05 Test Session.png",
+				type: "file",
+				stat: { type: "file", size: 100 },
+			},
+		]);
+		getSignedUrl.mockImplementation(async (_s3, command) => {
+			return `https://signed.example/${command.Key}`;
+		});
+	});
+
+	it("returns listing and presigned metadata URLs for authorized users", async () => {
+		const response = await GET(
+			request("http://localhost/api/aws_download?group=test&year=2024"),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(login).toHaveBeenCalledWith({
+			id: "user",
+			hash: "secret",
+			api: "aws",
+			path: "sessions/test/2024",
+		});
+		expect(list).toHaveBeenCalledWith({ path: "sessions/test/2024" });
+		expect(body.items).toHaveLength(1);
+		expect(body.urls.tags).toContain("sessions/test/2024.tags");
+		expect(body.urls.duration).toContain("sessions/test/2024.duration");
+		expect(body.urls.md).toContain("sessions/test/2024.md");
+		expect(body.urls.zip).toContain("sessions/test/2024.zip");
+	});
+
+	it("rejects requests without credentials", async () => {
+		parseCookie.mockReturnValue({});
+
+		const response = await GET(
+			request("http://localhost/api/aws_download?group=test&year=2024", ""),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(403);
+		expect(body.err).toBe("ACCESS_DENIED");
+		expect(list).not.toHaveBeenCalled();
+	});
+
+	it("rejects users without student access", async () => {
+		roleAuth.mockReturnValue(false);
+
+		const response = await GET(
+			request("http://localhost/api/aws_download?group=test&year=2024"),
+		);
+
+		expect(response.status).toBe(403);
+		expect(list).not.toHaveBeenCalled();
+	});
+});

--- a/src/util/domain/updateSessions/metadataAggregator.js
+++ b/src/util/domain/updateSessions/metadataAggregator.js
@@ -1,0 +1,84 @@
+import JSZip from "jszip";
+import {
+	getZipTextEntryId,
+	parseSessionMetadataJSON,
+	parseSummariesMarkdown,
+} from "./metadataParser";
+
+export function validateGroup(group) {
+	if (!group || typeof group !== "string") {
+		throw new Error("INVALID_GROUP");
+	}
+	if (!/^[^./\\][^/\\]*$/.test(group) || group.includes("..")) {
+		throw new Error("INVALID_GROUP");
+	}
+}
+
+export function validateYear(year) {
+	if (!/^\d{4}$/.test(String(year || ""))) {
+		throw new Error("INVALID_YEAR");
+	}
+}
+
+export function normalizeListedItem(item, basePath) {
+	const name = item.name;
+	const itemPath = `${basePath}/${name}`;
+	const stat = item.stat || {};
+	return {
+		name,
+		path: `/aws/${itemPath}`,
+		type: item.type || stat.type,
+		stat,
+		size: stat.size,
+		mtimeMs: stat.mtimeMs,
+	};
+}
+
+export async function parseTranscriptionZip(buffer) {
+	const transcriptions = Object.create(null);
+	if (!buffer) return transcriptions;
+
+	const zip = new JSZip();
+	await zip.loadAsync(buffer);
+	zip.forEach((relativePath, zipEntry) => {
+		const id = !zipEntry.dir && getZipTextEntryId(relativePath);
+		if (id) {
+			transcriptions[id] = true;
+		}
+	});
+	return transcriptions;
+}
+
+export async function aggregateSessionMetadataFromSources({
+	group,
+	year,
+	items,
+	tagsContent,
+	durationsContent,
+	summariesContent,
+	transcriptionsBuffer,
+}) {
+	let transcriptions = Object.create(null);
+	try {
+		transcriptions = await parseTranscriptionZip(transcriptionsBuffer);
+	} catch (err) {
+		console.warn(
+			`[SessionMetadata] Failed to parse transcription zip for ${group}/${year}`,
+			err,
+		);
+	}
+
+	const sortedItems = [...(items || [])].sort((a, b) =>
+		a.name.localeCompare(b.name),
+	);
+
+	return {
+		group,
+		year,
+		items: sortedItems,
+		tags: parseSessionMetadataJSON(tagsContent, "tags"),
+		durations: parseSessionMetadataJSON(durationsContent, "duration"),
+		summaries: parseSummariesMarkdown(summariesContent),
+		transcriptions,
+	};
+}

--- a/src/util/domain/updateSessions/metadataAggregator.test.js
+++ b/src/util/domain/updateSessions/metadataAggregator.test.js
@@ -1,0 +1,35 @@
+import JSZip from "jszip";
+import { aggregateSessionMetadataFromSources } from "./metadataAggregator";
+
+describe("aggregateSessionMetadataFromSources", () => {
+	it("parses consolidated metadata from provided sources", async () => {
+		const zip = new JSZip();
+		zip.file("Transcriptions/2024-05-05 Test Session.txt", "Transcript");
+		const zipBuffer = await zip.generateAsync({ type: "uint8array" });
+
+		const result = await aggregateSessionMetadataFromSources({
+			group: "test",
+			year: "2024",
+			items: [
+				{
+					name: "2024-05-05 Test Session.txt",
+					path: "/aws/sessions/test/2024/2024-05-05 Test Session.txt",
+				},
+			],
+			tagsContent: JSON.stringify({
+				sessions: [{ sessionName: "2024-05-05 Test Session", tags: ["ai."] }],
+			}),
+			durationsContent: JSON.stringify({
+				sessions: [{ sessionName: "2024-05-05 Test Session", duration: 123 }],
+			}),
+			summariesContent: "## 2024-05-05 Test Session\nSummary\n---\n",
+			transcriptionsBuffer: zipBuffer,
+		});
+
+		expect(result.items).toHaveLength(1);
+		expect(result.tags["2024-05-05 Test Session"]).toEqual(["ai"]);
+		expect(result.durations["2024-05-05 Test Session"]).toBe(123);
+		expect(result.summaries["2024-05-05 Test Session"]).toBe("Summary");
+		expect(result.transcriptions["2024-05-05 Test Session"]).toBe(true);
+	});
+});

--- a/src/util/domain/updateSessions/sessionMetadataClient.js
+++ b/src/util/domain/updateSessions/sessionMetadataClient.js
@@ -3,6 +3,7 @@ import { aggregateSessionMetadataFromSources } from "./metadataAggregator";
 
 const SESSION_METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
 const metadataCache = new Map();
+const pendingRequests = new Map();
 
 function getCacheKey(group, year, metadataFingerprint) {
 	return `${group}/${year}/${metadataFingerprint || "unknown"}`;
@@ -10,6 +11,7 @@ function getCacheKey(group, year, metadataFingerprint) {
 
 export function clearSessionMetadataCache() {
 	metadataCache.clear();
+	pendingRequests.clear();
 }
 
 export function seedSessionMetadataCache(group, year, metadataFingerprint, value) {
@@ -84,6 +86,18 @@ async function fetchSessionMetadataViaProxy(group, year) {
 	});
 }
 
+async function loadSessionMetadata(group, year) {
+	try {
+		return await fetchSessionMetadataViaPresign(group, year);
+	} catch (presignErr) {
+		console.warn(
+			`[SessionMetadata] Presigned fetch failed for ${group}/${year}; falling back to session-metadata API`,
+			presignErr,
+		);
+		return await fetchSessionMetadataViaProxy(group, year);
+	}
+}
+
 export async function fetchSessionMetadata(
 	group,
 	year,
@@ -96,22 +110,31 @@ export async function fetchSessionMetadata(
 		if (cached && cached.expiresAt > Date.now()) {
 			return cached.value;
 		}
+		if (pendingRequests.has(cacheKey)) {
+			return pendingRequests.get(cacheKey);
+		}
 	}
 
-	let value;
+	const promise = loadSessionMetadata(group, year);
+	if (!forceUpdate) {
+		pendingRequests.set(cacheKey, promise);
+	}
+
 	try {
-		value = await fetchSessionMetadataViaPresign(group, year);
-	} catch (presignErr) {
-		console.warn(
-			`[SessionMetadata] Presigned fetch failed for ${group}/${year}; falling back to session-metadata API`,
-			presignErr,
-		);
-		value = await fetchSessionMetadataViaProxy(group, year);
+		const value = await promise;
+		metadataCache.set(cacheKey, {
+			value,
+			expiresAt: Date.now() + SESSION_METADATA_CACHE_TTL_MS,
+		});
+		return value;
+	} catch (err) {
+		if (!forceUpdate) {
+			pendingRequests.delete(cacheKey);
+		}
+		throw err;
+	} finally {
+		if (!forceUpdate && pendingRequests.get(cacheKey) === promise) {
+			pendingRequests.delete(cacheKey);
+		}
 	}
-
-	metadataCache.set(cacheKey, {
-		value,
-		expiresAt: Date.now() + SESSION_METADATA_CACHE_TTL_MS,
-	});
-	return value;
 }

--- a/src/util/domain/updateSessions/sessionMetadataClient.js
+++ b/src/util/domain/updateSessions/sessionMetadataClient.js
@@ -1,4 +1,5 @@
 import { fetchJSON } from "@util/api/fetch";
+import { aggregateSessionMetadataFromSources } from "./metadataAggregator";
 
 const SESSION_METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
 const metadataCache = new Map();
@@ -11,7 +12,84 @@ export function clearSessionMetadataCache() {
 	metadataCache.clear();
 }
 
-export async function fetchSessionMetadata(group, year, metadataFingerprint, forceUpdate = false) {
+export function seedSessionMetadataCache(group, year, metadataFingerprint, value) {
+	const cacheKey = getCacheKey(group, year, metadataFingerprint);
+	metadataCache.set(cacheKey, {
+		value,
+		expiresAt: Date.now() + SESSION_METADATA_CACHE_TTL_MS,
+	});
+}
+
+async function fetchTextFromUrl(url) {
+	if (!url) return null;
+	const response = await fetch(url, { method: "GET" });
+	if (response.status === 404) return null;
+	if (!response.ok) {
+		throw new Error(`Failed to fetch metadata (${response.status})`);
+	}
+	return await response.text();
+}
+
+async function fetchBinaryFromUrl(url) {
+	if (!url) return null;
+	const response = await fetch(url, { method: "GET" });
+	if (response.status === 404) return null;
+	if (!response.ok) {
+		throw new Error(`Failed to fetch metadata binary (${response.status})`);
+	}
+	return await response.arrayBuffer();
+}
+
+async function fetchSessionMetadataViaPresign(group, year) {
+	const params = new URLSearchParams({
+		group,
+		year: String(year),
+	});
+	const payload = await fetchJSON(`/api/aws_download?${params.toString()}`, {
+		method: "GET",
+		cache: "no-store",
+	});
+	if (payload?.err) {
+		throw new Error(payload.err);
+	}
+
+	const urls = payload?.urls || {};
+	const [tagsContent, durationsContent, summariesContent, transcriptionsBuffer] =
+		await Promise.all([
+			fetchTextFromUrl(urls.tags),
+			fetchTextFromUrl(urls.duration),
+			fetchTextFromUrl(urls.md),
+			fetchBinaryFromUrl(urls.zip),
+		]);
+
+	return aggregateSessionMetadataFromSources({
+		group,
+		year,
+		items: payload?.items || [],
+		tagsContent,
+		durationsContent,
+		summariesContent,
+		transcriptionsBuffer,
+	});
+}
+
+async function fetchSessionMetadataViaProxy(group, year) {
+	const params = new URLSearchParams({
+		group,
+		year: String(year),
+	});
+	return await fetchJSON(`/api/session-metadata?${params.toString()}`, {
+		method: "GET",
+		cache: "no-store",
+	});
+}
+
+export async function fetchSessionMetadata(
+	group,
+	year,
+	metadataFingerprint,
+	forceUpdate = false,
+) {
 	const cacheKey = getCacheKey(group, year, metadataFingerprint);
 	if (!forceUpdate) {
 		const cached = metadataCache.get(cacheKey);
@@ -20,14 +98,17 @@ export async function fetchSessionMetadata(group, year, metadataFingerprint, for
 		}
 	}
 
-	const params = new URLSearchParams({
-		group,
-		year: String(year),
-	});
-	const value = await fetchJSON(`/api/session-metadata?${params.toString()}`, {
-		method: "GET",
-		cache: "no-store",
-	});
+	let value;
+	try {
+		value = await fetchSessionMetadataViaPresign(group, year);
+	} catch (presignErr) {
+		console.warn(
+			`[SessionMetadata] Presigned fetch failed for ${group}/${year}; falling back to session-metadata API`,
+			presignErr,
+		);
+		value = await fetchSessionMetadataViaProxy(group, year);
+	}
+
 	metadataCache.set(cacheKey, {
 		value,
 		expiresAt: Date.now() + SESSION_METADATA_CACHE_TTL_MS,

--- a/src/util/domain/updateSessions/sessionMetadataClient.test.js
+++ b/src/util/domain/updateSessions/sessionMetadataClient.test.js
@@ -1,5 +1,8 @@
 import { fetchJSON } from "@util/api/fetch";
-import { fetchSessionMetadata } from "./sessionMetadataClient";
+import {
+	clearSessionMetadataCache,
+	fetchSessionMetadata,
+} from "./sessionMetadataClient";
 
 jest.mock("@util/api/fetch", () => ({
 	fetchJSON: jest.fn(),
@@ -10,6 +13,7 @@ const originalFetch = global.fetch;
 describe("fetchSessionMetadata", () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		clearSessionMetadataCache();
 		global.fetch = jest.fn();
 	});
 
@@ -105,5 +109,54 @@ describe("fetchSessionMetadata", () => {
 			expect.any(Object),
 		);
 		expect(result.tags["2024-05-05 Test Session"]).toEqual(["fallback"]);
+	});
+
+	it("dedupes concurrent requests for the same metadata key", async () => {
+		let resolveFetch;
+		const fetchGate = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+		fetchJSON.mockImplementation(async () => {
+			await fetchGate;
+			return {
+				group: "test",
+				year: "2024",
+				items: [],
+				urls: { tags: null, duration: null, md: null, zip: null },
+			};
+		});
+
+		const first = fetchSessionMetadata("test", "2024", "fp-1", false);
+		const second = fetchSessionMetadata("test", "2024", "fp-1", false);
+
+		resolveFetch();
+		const [resultA, resultB] = await Promise.all([first, second]);
+
+		expect(fetchJSON).toHaveBeenCalledTimes(1);
+		expect(resultA).toBe(resultB);
+	});
+
+	it("does not dedupe concurrent requests when forceUpdate is true", async () => {
+		let resolveFetch;
+		const fetchGate = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+		fetchJSON.mockImplementation(async () => {
+			await fetchGate;
+			return {
+				group: "test",
+				year: "2024",
+				items: [],
+				urls: { tags: null, duration: null, md: null, zip: null },
+			};
+		});
+
+		const first = fetchSessionMetadata("test", "2024", "fp-1", true);
+		const second = fetchSessionMetadata("test", "2024", "fp-1", true);
+
+		resolveFetch();
+		await Promise.all([first, second]);
+
+		expect(fetchJSON).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/util/domain/updateSessions/sessionMetadataClient.test.js
+++ b/src/util/domain/updateSessions/sessionMetadataClient.test.js
@@ -1,0 +1,109 @@
+import { fetchJSON } from "@util/api/fetch";
+import { fetchSessionMetadata } from "./sessionMetadataClient";
+
+jest.mock("@util/api/fetch", () => ({
+	fetchJSON: jest.fn(),
+}));
+
+const originalFetch = global.fetch;
+
+describe("fetchSessionMetadata", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		global.fetch = jest.fn();
+	});
+
+	afterEach(() => {
+		global.fetch = originalFetch;
+	});
+
+	it("aggregates metadata from presigned URLs without calling session-metadata", async () => {
+		fetchJSON.mockResolvedValue({
+			group: "test",
+			year: "2024",
+			items: [{ name: "2024-05-05 Test Session.txt", path: "/aws/sessions/test/2024/2024-05-05 Test Session.txt" }],
+			urls: {
+				tags: "https://signed/tags",
+				duration: "https://signed/duration",
+				md: "https://signed/md",
+				zip: null,
+			},
+		});
+		global.fetch.mockImplementation(async (url) => {
+			if (url === "https://signed/tags") {
+				return {
+					ok: true,
+					status: 200,
+					text: async () =>
+						JSON.stringify({
+							sessions: [
+								{ sessionName: "2024-05-05 Test Session", tags: ["ai"] },
+							],
+						}),
+				};
+			}
+			if (url === "https://signed/duration") {
+				return {
+					ok: true,
+					status: 200,
+					text: async () =>
+						JSON.stringify({
+							sessions: [
+								{ sessionName: "2024-05-05 Test Session", duration: 123 },
+							],
+						}),
+				};
+			}
+			if (url === "https://signed/md") {
+				return {
+					ok: true,
+					status: 200,
+					text: async () => "## 2024-05-05 Test Session\nSummary\n",
+				};
+			}
+			return { ok: false, status: 404 };
+		});
+
+		const result = await fetchSessionMetadata("test", "2024", [], false);
+
+		expect(fetchJSON).toHaveBeenCalledWith(
+			expect.stringContaining("/api/aws_download?"),
+			expect.objectContaining({ method: "GET" }),
+		);
+		expect(fetchJSON).not.toHaveBeenCalledWith(
+			expect.stringContaining("/api/session-metadata"),
+			expect.anything(),
+		);
+		expect(result.tags["2024-05-05 Test Session"]).toEqual(["ai"]);
+		expect(result.durations["2024-05-05 Test Session"]).toBe(123);
+		expect(result.summaries["2024-05-05 Test Session"]).toBe("Summary");
+	});
+
+	it("falls back to session-metadata when presign fetch fails", async () => {
+		fetchJSON
+			.mockRejectedValueOnce(new Error("presign failed"))
+			.mockResolvedValueOnce({
+				group: "test",
+				year: "2024",
+				items: [],
+				tags: { "2024-05-05 Test Session": ["fallback"] },
+				durations: {},
+				summaries: {},
+				transcriptions: {},
+			});
+
+		const result = await fetchSessionMetadata("test", "2024", [], true);
+
+		expect(fetchJSON).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining("/api/aws_download?"),
+			expect.any(Object),
+		);
+		expect(fetchJSON).toHaveBeenNthCalledWith(
+			2,
+			expect.stringContaining("/api/session-metadata?"),
+			expect.any(Object),
+		);
+		expect(result.tags["2024-05-05 Test Session"]).toEqual(["fallback"]);
+	});
+});

--- a/src/util/domain/updateSessions/sessionMetadataServer.js
+++ b/src/util/domain/updateSessions/sessionMetadataServer.js
@@ -4,27 +4,12 @@ import {
 	metadataInfo,
 	validatePathAccess,
 } from "@util/storage/aws";
-import JSZip from "jszip";
 import {
-	getZipTextEntryId,
-	parseSessionMetadataJSON,
-	parseSummariesMarkdown,
-} from "./metadataParser";
-
-function validateGroup(group) {
-	if (!group || typeof group !== "string") {
-		throw new Error("INVALID_GROUP");
-	}
-	if (!/^[^./\\][^/\\]*$/.test(group) || group.includes("..")) {
-		throw new Error("INVALID_GROUP");
-	}
-}
-
-function validateYear(year) {
-	if (!/^\d{4}$/.test(String(year || ""))) {
-		throw new Error("INVALID_YEAR");
-	}
-}
+	aggregateSessionMetadataFromSources,
+	normalizeListedItem,
+	validateGroup,
+	validateYear,
+} from "./metadataAggregator";
 
 async function readTextIfExists(path) {
 	const info = await metadataInfo({ path });
@@ -42,35 +27,6 @@ async function readBinaryIfExists(path) {
 	return await downloadData({ path, binary: true });
 }
 
-function normalizeListedItem(item, basePath) {
-	const name = item.name;
-	const itemPath = `${basePath}/${name}`;
-	const stat = item.stat || {};
-	return {
-		name,
-		path: `/aws/${itemPath}`,
-		type: item.type || stat.type,
-		stat,
-		size: stat.size,
-		mtimeMs: stat.mtimeMs,
-	};
-}
-
-async function parseTranscriptionZip(buffer) {
-	const transcriptions = Object.create(null);
-	if (!buffer) return transcriptions;
-
-	const zip = new JSZip();
-	await zip.loadAsync(buffer);
-	zip.forEach((relativePath, zipEntry) => {
-		const id = !zipEntry.dir && getZipTextEntryId(relativePath);
-		if (id) {
-			transcriptions[id] = true;
-		}
-	});
-	return transcriptions;
-}
-
 export async function aggregateSessionMetadata({ group, year }) {
 	validateGroup(group);
 	validateYear(year);
@@ -81,7 +37,6 @@ export async function aggregateSessionMetadata({ group, year }) {
 	const items = (await list({ path: basePath })).map((item) =>
 		normalizeListedItem(item, basePath),
 	);
-	items.sort((a, b) => a.name.localeCompare(b.name));
 
 	const metadataBasePath = `sessions/${group}`;
 	const [
@@ -96,23 +51,13 @@ export async function aggregateSessionMetadata({ group, year }) {
 		readBinaryIfExists(`${metadataBasePath}/${year}.zip`),
 	]);
 
-	let transcriptions = Object.create(null);
-	try {
-		transcriptions = await parseTranscriptionZip(transcriptionsBuffer);
-	} catch (err) {
-		console.warn(
-			`[SessionMetadata] Failed to parse transcription zip for ${group}/${year}`,
-			err,
-		);
-	}
-
-	return {
+	return aggregateSessionMetadataFromSources({
 		group,
 		year,
 		items,
-		tags: parseSessionMetadataJSON(tagsContent, "tags"),
-		durations: parseSessionMetadataJSON(durationsContent, "duration"),
-		summaries: parseSummariesMarkdown(summariesContent),
-		transcriptions,
-	};
+		tagsContent,
+		durationsContent,
+		summariesContent,
+		transcriptionsBuffer,
+	});
 }

--- a/src/util/domain/updateSessions/updateGroup.js
+++ b/src/util/domain/updateSessions/updateGroup.js
@@ -159,6 +159,31 @@ function getCombinedYearFingerprint(yearItems, metadataFingerprint) {
 	});
 }
 
+function serializeMetadataFingerprint(metadataFingerprint) {
+	return JSON.stringify(metadataFingerprint);
+}
+
+function normalizeMetadataPayload(metadata) {
+	return {
+		items: metadata?.items || [],
+		tags: metadata?.tags || {},
+		durations: metadata?.durations || {},
+		summaries: metadata?.summaries || {},
+		transcriptions: metadata?.transcriptions || {},
+	};
+}
+
+function getMetadataFromYearCache(yearCache, metadataFingerprint) {
+	if (!yearCache?.metadata) {
+		return null;
+	}
+	const fingerprintKey = serializeMetadataFingerprint(metadataFingerprint);
+	if (yearCache.metadataFingerprint !== fingerprintKey) {
+		return null;
+	}
+	return normalizeMetadataPayload(yearCache.metadata);
+}
+
 function getYearCachePath(groupName, yearName) {
 	return makePath(GROUP_UPDATE_CACHE_PATH, groupName, `${yearName}.json`);
 }
@@ -177,7 +202,13 @@ async function readYearCache(groupName, yearName) {
 	}
 }
 
-async function writeYearCache(groupName, yearName, fingerprint) {
+async function writeYearCache(
+	groupName,
+	yearName,
+	fingerprint,
+	metadataFingerprint,
+	metadata,
+) {
 	try {
 		const path = getYearCachePath(groupName, yearName);
 		await storage.createFolderPath(path);
@@ -185,6 +216,8 @@ async function writeYearCache(groupName, yearName, fingerprint) {
 			path,
 			JSON.stringify({
 				fingerprint,
+				metadataFingerprint: serializeMetadataFingerprint(metadataFingerprint),
+				metadata: normalizeMetadataPayload(metadata),
 				updatedAt: Date.now(),
 			}),
 		);
@@ -333,15 +366,30 @@ async function getYearMetadata(
 	metadataFingerprint,
 ) {
 	const awsPath = makePath("aws/sessions", name);
+	const yearCache = await readYearCache(name, year.name);
+	const cachedFromYearCache = getMetadataFromYearCache(
+		yearCache,
+		metadataFingerprint,
+	);
+	if (cachedFromYearCache) {
+		return cachedFromYearCache;
+	}
+
+	const fingerprintKey = serializeMetadataFingerprint(metadataFingerprint);
+	const yearCacheFingerprintMatches =
+		yearCache?.metadataFingerprint === fingerprintKey;
+
 	if (!forceUpdate) {
-		const cached = await loadCachedYearMetadata(
-			name,
-			year.name,
-			isMerged,
-			isBundled,
-		);
-		if (cached) {
-			return cached;
+		if (!yearCache || yearCacheFingerprintMatches) {
+			const cached = await loadCachedYearMetadata(
+				name,
+				year.name,
+				isMerged,
+				isBundled,
+			);
+			if (cached) {
+				return cached;
+			}
 		}
 	}
 
@@ -352,13 +400,7 @@ async function getYearMetadata(
 			metadataFingerprint,
 			forceUpdate,
 		);
-		return {
-			items: metadata?.items || [],
-			tags: metadata?.tags || {},
-			durations: metadata?.durations || {},
-			summaries: metadata?.summaries || {},
-			transcriptions: metadata?.transcriptions || {},
-		};
+		return normalizeMetadataPayload(metadata);
 	} catch (err) {
 		console.warn(
 			`[UpdateGroup] Aggregated metadata fetch failed for ${name}/${year.name}; falling back to legacy metadata reads`,
@@ -824,7 +866,19 @@ export async function updateGroupProcess(
 						});
 					}
 				}
-				await writeYearCache(name, year.name, yearFingerprint);
+				await writeYearCache(
+					name,
+					year.name,
+					yearFingerprint,
+					metadataFingerprint,
+					{
+						items: metadataYearItems,
+						tags: sessionTagsMap,
+						durations: sessionDurationMap,
+						summaries: sessionSummariesMap,
+						transcriptions: sessionTranscriptionMap,
+					},
+				);
 			} catch (err) {
 				console.error(err);
 				UpdateSessionsStore.update((s) => {

--- a/src/util/domain/updateSessions/updateGroup.test.js
+++ b/src/util/domain/updateSessions/updateGroup.test.js
@@ -31,9 +31,11 @@ jest.mock("@util/data/image", () => ({
 	shrinkImage: jest.fn(),
 }));
 jest.mock("@util/storage/storage", () => ({
+	createFolderPath: jest.fn(),
 	deleteFile: jest.fn(),
 	exists: jest.fn(),
 	readFile: jest.fn(),
+	writeFile: jest.fn(),
 }));
 jest.mock("./cleanup", () => ({
 	cleanupBundledGroup: jest.fn(),
@@ -245,11 +247,13 @@ describe("updateGroupProcess", () => {
 			}
 			return [];
 		});
-		storage.exists.mockImplementation(async (path) =>
-			path.endsWith(`test/${currentYear}.json`),
-		);
+		const localYearPath = `/local/sync/test/${currentYear}.json`;
+		storage.exists.mockImplementation(async (path) => path === localYearPath);
 		storage.readFile.mockImplementation(async (path) => {
-			if (path.endsWith(`test/${currentYear}.json`)) {
+			if (path.includes(".group-update-cache")) {
+				return "";
+			}
+			if (path === localYearPath) {
 				return JSON.stringify({
 					sessions: [
 						{
@@ -281,5 +285,171 @@ describe("updateGroupProcess", () => {
 		expect(sessions[0].duration).toBe(321);
 		expect(sessions[0].summaryText).toBe("Cached summary");
 		expect(sessions[0].transcription).toBe(true);
+	});
+
+	it("skips remote metadata fetch when year cache metadata fingerprint is unchanged", async () => {
+		const metadataFiles = [
+			{ name: "2024.tags", size: 100, mtimeMs: 1 },
+			{ name: "2024.duration", size: 100, mtimeMs: 1 },
+			{ name: "2024.md", size: 100, mtimeMs: 1 },
+			{ name: "2024.zip", size: 100, mtimeMs: 1 },
+		];
+		const metadataFingerprint = [
+			{ name: "2024.tags", type: "", size: 100, mtimeMs: 1 },
+			{ name: "2024.duration", type: "", size: 100, mtimeMs: 1 },
+			{ name: "2024.md", type: "", size: 100, mtimeMs: 1 },
+			{ name: "2024.zip", type: "", size: 100, mtimeMs: 1 },
+		];
+
+		getListing.mockImplementation(async (path) => {
+			if (path === "wasabi/test") {
+				return [{ name: "2024", type: "dir", path: "wasabi/test/2024" }];
+			}
+			if (path === "wasabi/test/2024") {
+				return [
+					file(
+						"2024-05-05 Test Session.mp4",
+						"wasabi/test/2024/2024-05-05 Test Session.mp4",
+					),
+					file(
+						"2024-05-06 New Session.mp4",
+						"wasabi/test/2024/2024-05-06 New Session.mp4",
+					),
+				];
+			}
+			if (path === "/aws/sessions/test") {
+				return metadataFiles;
+			}
+			return [];
+		});
+
+		storage.readFile.mockImplementation(async (path) => {
+			if (path.includes(".group-update-cache/test/2024.json")) {
+				return JSON.stringify({
+					fingerprint: "stale-combined-fingerprint",
+					metadataFingerprint: JSON.stringify(metadataFingerprint),
+					metadata: {
+						items: [
+							file(
+								"2024-05-05 Test Session.png",
+								"/aws/sessions/test/2024/2024-05-05 Test Session.png",
+							),
+						],
+						tags: { "2024-05-05 Test Session": ["cached-tag"] },
+						durations: { "2024-05-05 Test Session": 999 },
+						summaries: { "2024-05-05 Test Session": "Cached summary" },
+						transcriptions: { "2024-05-05 Test Session": true },
+					},
+				});
+			}
+			return "";
+		});
+
+		await updateGroupProcess("test", true, false);
+
+		expect(fetchSessionMetadata).not.toHaveBeenCalled();
+		const [, , sessions] = updateYearSync.mock.calls[0];
+		expect(sessions[0].tags).toEqual(["cached-tag"]);
+		expect(sessions[0].duration).toBe(999);
+		expect(sessions[0].summaryText).toBe("Cached summary");
+	});
+
+	it("skips remote metadata fetch on forceUpdate when metadata fingerprint is unchanged", async () => {
+		const metadataFingerprint = [
+			{ name: "2024.tags", type: "", size: 100, mtimeMs: 1 },
+			{ name: "2024.duration", type: "", size: 100, mtimeMs: 1 },
+			{ name: "2024.md", type: "", size: 100, mtimeMs: 1 },
+			{ name: "2024.zip", type: "", size: 100, mtimeMs: 1 },
+		];
+
+		getListing.mockImplementation(async (path) => {
+			if (path === "wasabi/test") {
+				return [{ name: "2024", type: "dir", path: "wasabi/test/2024" }];
+			}
+			if (path === "wasabi/test/2024") {
+				return [
+					file(
+						"2024-05-05 Test Session.mp4",
+						"wasabi/test/2024/2024-05-05 Test Session.mp4",
+					),
+				];
+			}
+			if (path === "/aws/sessions/test") {
+				return [
+					{ name: "2024.tags", size: 100, mtimeMs: 1 },
+					{ name: "2024.duration", size: 100, mtimeMs: 1 },
+					{ name: "2024.md", size: 100, mtimeMs: 1 },
+					{ name: "2024.zip", size: 100, mtimeMs: 1 },
+				];
+			}
+			return [];
+		});
+
+		storage.readFile.mockImplementation(async (path) => {
+			if (path.includes(".group-update-cache/test/2024.json")) {
+				return JSON.stringify({
+					fingerprint: "stale-combined-fingerprint",
+					metadataFingerprint: JSON.stringify(metadataFingerprint),
+					metadata: {
+						items: [],
+						tags: { "2024-05-05 Test Session": ["forced-cache"] },
+						durations: { "2024-05-05 Test Session": 555 },
+						summaries: {},
+						transcriptions: {},
+					},
+				});
+			}
+			return "";
+		});
+
+		await updateGroupProcess("test", true, true);
+
+		expect(fetchSessionMetadata).not.toHaveBeenCalled();
+		const [, , sessions] = updateYearSync.mock.calls[0];
+		expect(sessions[0].tags).toEqual(["forced-cache"]);
+		expect(sessions[0].duration).toBe(555);
+	});
+
+	it("fetches remote metadata when metadata fingerprint changes", async () => {
+		getListing.mockImplementation(async (path) => {
+			if (path === "wasabi/test") {
+				return [{ name: "2024", type: "dir", path: "wasabi/test/2024" }];
+			}
+			if (path === "wasabi/test/2024") {
+				return [
+					file(
+						"2024-05-05 Test Session.mp4",
+						"wasabi/test/2024/2024-05-05 Test Session.mp4",
+					),
+				];
+			}
+			if (path === "/aws/sessions/test") {
+				return [{ name: "2024.tags", size: 200, mtimeMs: 2 }];
+			}
+			return [];
+		});
+
+		storage.readFile.mockImplementation(async (path) => {
+			if (path.includes(".group-update-cache/test/2024.json")) {
+				return JSON.stringify({
+					fingerprint: "old",
+					metadataFingerprint: JSON.stringify([
+						{ name: "2024.tags", type: "", size: 100, mtimeMs: 1 },
+					]),
+					metadata: {
+						items: [],
+						tags: { "2024-05-05 Test Session": ["stale"] },
+						durations: {},
+						summaries: {},
+						transcriptions: {},
+					},
+				});
+			}
+			return "";
+		});
+
+		await updateGroupProcess("test", true, false);
+
+		expect(fetchSessionMetadata).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
…d S3 reads.

Gate metadata fetches on fingerprint-matched year cache, add aws_download batch presign route, and aggregate metadata client-side with session-metadata fallback.